### PR TITLE
fix: ArgumentException in GetOpConfigurationSections when multiple nested keys have the same name

### DIFF
--- a/src/Hosting.Extensions.1Password/OnePasswordHostingExtension.cs
+++ b/src/Hosting.Extensions.1Password/OnePasswordHostingExtension.cs
@@ -15,8 +15,6 @@ namespace Arkanis.Hosting.Extensions._1Password
     /// </summary>
     public static class OnePasswordHostingExtension
     {
-        private static readonly char[] EqualsSeparator = { '=' };
-
         /// <summary>
         /// Internal factory for creating IOpCliInvoker instances. Used for testing.
         /// </summary>
@@ -68,7 +66,7 @@ namespace Arkanis.Hosting.Extensions._1Password
             foreach (var line in result.StandardOutput.Split("\n").Where(line => !string.IsNullOrWhiteSpace(line)))
             {
                 // Split into max 2 parts to handle values containing "="
-                var parts = line.Split(EqualsSeparator, 2);
+                var parts = line.Split('=',2);
                 if (parts.Length != 2)
                 {
                     if (failSilently)
@@ -118,7 +116,7 @@ namespace Arkanis.Hosting.Extensions._1Password
             {
                 if (section.Value is { } s && s.StartsWith("op://", StringComparison.OrdinalIgnoreCase))
                 {
-                    opSections.Add(section.Key, section);
+                    opSections.Add(section.Path.Replace(':','_'), section);
                 }
                 else
                 {

--- a/tests/Hosting.Extensions.1Password.UnitTests/ComplexNestedSecretsTests.cs
+++ b/tests/Hosting.Extensions.1Password.UnitTests/ComplexNestedSecretsTests.cs
@@ -38,14 +38,14 @@ public class ComplexNestedSecretsTests : IDisposable
             ["Level1:Level2:Level3:Level4:Secret"] = "op://vault/item/field1",
             ["Level1:Level2:Level3:OtherValue"] = "plain-value",
             ["Level1:Level2:AnotherSecret"] = "op://vault/item/field2",
-            ["Level1:NonSecret"] = "plain-value-2"
+            ["Level1:NonSecret"] = "plain-value-2",
         };
 
         var builder = CreateHostApplicationBuilder(configuration);
 
         var mockInvoker = new FakeOpCliInvoker(
-            "Secret=\"resolved-secret-1\"\n" +
-            "AnotherSecret=\"resolved-secret-2\"");
+            "Level1_Level2_Level3_Level4_Secret=\"resolved-secret-1\"\n" + "Level1_Level2_AnotherSecret=\"resolved-secret-2\""
+        );
         OnePasswordHostingExtension.InvokerFactory = () => mockInvoker;
 
         // Act
@@ -70,15 +70,16 @@ public class ComplexNestedSecretsTests : IDisposable
             ["ConnectionStrings:Primary"] = "op://vault/db1/connection",
             ["ConnectionStrings:Backup"] = "plain-connection-string",
             ["ConnectionStrings:Secondary"] = "op://vault/db2/connection",
-            ["ConnectionStrings:Tertiary"] = "op://vault/db3/connection"
+            ["ConnectionStrings:Tertiary"] = "op://vault/db3/connection",
         };
 
         var builder = CreateHostApplicationBuilder(configuration);
 
         var mockInvoker = new FakeOpCliInvoker(
-            "Primary=\"Server=db1;User=user1\"\n" +
-            "Secondary=\"Server=db2;User=user2\"\n" +
-            "Tertiary=\"Server=db3;User=user3\"");
+            "ConnectionStrings_Primary=\"Server=db1;User=user1\"\n"
+            + "ConnectionStrings_Secondary=\"Server=db2;User=user2\"\n"
+            + "ConnectionStrings_Tertiary=\"Server=db3;User=user3\""
+        );
         OnePasswordHostingExtension.InvokerFactory = () => mockInvoker;
 
         // Act
@@ -107,16 +108,17 @@ public class ComplexNestedSecretsTests : IDisposable
             ["Services:Api:BaseUrl"] = "https://api.example.com",
             ["Services:Api:ApiKey"] = "op://vault/api/key",
             ["Services:Cache:Type"] = "Redis",
-            ["Services:Cache:ConnectionString"] = "op://vault/redis/connection"
+            ["Services:Cache:ConnectionString"] = "op://vault/redis/connection",
         };
 
         var builder = CreateHostApplicationBuilder(configuration);
 
         var mockInvoker = new FakeOpCliInvoker(
-            "Username=\"dbuser\"\n" +
-            "Password=\"dbpass123\"\n" +
-            "ApiKey=\"apikey456\"\n" +
-            "ConnectionString=\"redis://localhost:6379\"");
+            "Services_Database_Username=\"dbuser\"\n"
+            + "Services_Database_Password=\"dbpass123\"\n"
+            + "Services_Api_ApiKey=\"apikey456\"\n"
+            + "Services_Cache_ConnectionString=\"redis://localhost:6379\""
+        );
         OnePasswordHostingExtension.InvokerFactory = () => mockInvoker;
 
         // Act
@@ -148,15 +150,12 @@ public class ComplexNestedSecretsTests : IDisposable
             ["Endpoints:1:Name"] = "Service2",
             ["Endpoints:1:Url"] = "https://service2.example.com",
             ["Endpoints:1:Token"] = "op://vault/service2/token",
-            ["Endpoints:1:Secret"] = "op://vault/service2/secret"
+            ["Endpoints:1:Secret"] = "op://vault/service2/secret",
         };
 
         var builder = CreateHostApplicationBuilder(configuration);
 
-        var mockInvoker = new FakeOpCliInvoker(
-            "ApiKey=\"key123\"\n" +
-            "Token=\"token456\"\n" +
-            "Secret=\"secret789\"");
+        var mockInvoker = new FakeOpCliInvoker("Endpoints_0_ApiKey=\"key123\"\n" + "Endpoints_1_Token=\"token456\"\n" + "Endpoints_1_Secret=\"secret789\"");
         OnePasswordHostingExtension.InvokerFactory = () => mockInvoker;
 
         // Act
@@ -183,14 +182,15 @@ public class ComplexNestedSecretsTests : IDisposable
         {
             ["AppSettings:Feature_Alpha:AlphaKey"] = "op://vault/alpha/key",
             ["AppSettings:Feature_Beta:BetaSecret"] = "op://vault/beta/secret",
-            ["AppSettings:Feature_Beta:NestedValue"] = "plain-value"
+            ["AppSettings:Feature_Beta:NestedValue"] = "plain-value",
         };
 
         var builder = CreateHostApplicationBuilder(configuration);
 
+
         var mockInvoker = new FakeOpCliInvoker(
-            "AlphaKey=\"alphakey123\"\n" +
-            "BetaSecret=\"betasecret456\"");
+            "AppSettings_Feature_Alpha_AlphaKey=\"alphakey123\"\n" + "AppSettings_Feature_Beta_BetaSecret=\"betasecret456\""
+        );
         OnePasswordHostingExtension.InvokerFactory = () => mockInvoker;
 
         // Act
@@ -212,13 +212,12 @@ public class ComplexNestedSecretsTests : IDisposable
         var configuration = new Dictionary<string, string?>
         {
             ["A:B:C:D:E:F:G:H:I:J:DeepSecret"] = "op://vault/deep/secret",
-            ["A:B:C:D:E:F:G:H:I:J:Plain"] = "plain-value"
+            ["A:B:C:D:E:F:G:H:I:J:Plain"] = "plain-value",
         };
 
         var builder = CreateHostApplicationBuilder(configuration);
 
-        var mockInvoker = new FakeOpCliInvoker(
-            "DeepSecret=\"deep-secret-value\"");
+        var mockInvoker = new FakeOpCliInvoker("A_B_C_D_E_F_G_H_I_J_DeepSecret=\"deep-secret-value\"");
         OnePasswordHostingExtension.InvokerFactory = () => mockInvoker;
 
         // Act
@@ -240,17 +239,16 @@ public class ComplexNestedSecretsTests : IDisposable
         {
             ["Section1:Nested:Secret1"] = "op://vault/item1/field1",
             ["Section2:Deep:Nested:Secret2"] = "op://vault/item2/field2",
-            ["Section3:Secret3"] = "op://vault/item3/field3"
+            ["Section3:Secret3"] = "op://vault/item3/field3",
         };
 
         var builder = CreateHostApplicationBuilder(configuration);
 
         var invocationCount = 0;
         var mockInvoker = new FakeOpCliInvokerWithCounter(
-            "Secret1=\"value1\"\n" +
-            "Secret2=\"value2\"\n" +
-            "Secret3=\"value3\"",
-            () => invocationCount++);
+            "Section1_Nested_Secret1=\"value1\"\n" + "Section2_Deep_Nested_Secret2=\"value2\"\n" + "Section3_Secret3=\"value3\"",
+            () => invocationCount++
+        );
         OnePasswordHostingExtension.InvokerFactory = () => mockInvoker;
 
         // Act
@@ -261,6 +259,43 @@ public class ComplexNestedSecretsTests : IDisposable
         Assert.Equal((string?)"value1", builder.Configuration.GetSection("Section1:Nested:Secret1").Value);
         Assert.Equal((string?)"value2", builder.Configuration.GetSection("Section2:Deep:Nested:Secret2").Value);
         Assert.Equal((string?)"value3", builder.Configuration.GetSection("Section3:Secret3").Value);
+    }
+
+    /// <summary>
+    /// Ensures that if there are duplicate leaf key names in different nested sections, they are all resolved correctly without conflicts.
+    /// </summary>
+    [Fact]
+    public async Task Use1PasswordAsync_DuplicateLeafKeyNames_ResolveSuccessfully()
+    {
+        // Arrange
+        var configuration = new Dictionary<string, string?>
+        {
+            ["Section1:Nested:DuplicateKey"] = "op://vault/item1/field1",
+            ["Section2:Nested:DuplicateKey"] = "op://vault/item2/field1",
+            ["Section3:NestedArray:0:DuplicateKey"] = "op://vault/item3/field1",
+            ["Section3:NestedArray:1:DuplicateKey"] = "op://vault/item4/field1",
+            ["Section3:NestedArray:2:DuplicateKey"] = "op://vault/item4/field2",
+        };
+
+        var builder = CreateHostApplicationBuilder(configuration);
+        var mockInvoker = new FakeOpCliInvoker(
+            "Section1_Nested_DuplicateKey=\"Password1\"\n"
+            + "Section2_Nested_DuplicateKey=\"Password2\"\n"
+            + "Section3_NestedArray_0_DuplicateKey=\"Password3\"\n"
+            + "Section3_NestedArray_1_DuplicateKey=\"Password4\"\n"
+            + "Section3_NestedArray_2_DuplicateKey=\"Password5\""
+        );
+        OnePasswordHostingExtension.InvokerFactory = () => mockInvoker;
+
+        // Act
+        await builder.Use1PasswordAsync();
+
+        // Assert
+        Assert.Equal((string?)"Password1", builder.Configuration.GetSection("Section1:Nested:DuplicateKey").Value);
+        Assert.Equal((string?)"Password2", builder.Configuration.GetSection("Section2:Nested:DuplicateKey").Value);
+        Assert.Equal((string?)"Password3", builder.Configuration.GetSection("Section3:NestedArray:0:DuplicateKey").Value);
+        Assert.Equal((string?)"Password4", builder.Configuration.GetSection("Section3:NestedArray:1:DuplicateKey").Value);
+        Assert.Equal((string?)"Password5", builder.Configuration.GetSection("Section3:NestedArray:2:DuplicateKey").Value);
     }
 
     private static FakeHostApplicationBuilder CreateHostApplicationBuilder(IDictionary<string, string?> values)


### PR DESCRIPTION
Fixes #1 by switching from using the section key to its path.
Sanitizes paths by replacing the colon seperator with underscores before passing it to `op inject`.