### PR TITLE
fix: exclude global usings for Aspire extension

### DIFF
--- a/scripts/release-11-verify-nuget.sh
+++ b/scripts/release-11-verify-nuget.sh
@@ -14,5 +14,5 @@ THIS_DIR="$(dirname "$(realpath "$0")")"
 #| `stderr`         | Can be used for logging.                                                 |
 
 # calling shared function from common-verify.sh
-build_nuget "Hosting.Extensions.1Password" "publish-nuget"
-build_nuget "Aspire.Hosting.Extensions.1Password" "publish-nuget"
+build_nuget "Hosting.Extensions.1Password" "publish-common-nuget"
+build_nuget "Aspire.Hosting.Extensions.1Password" "publish-aspire-nuget"

--- a/scripts/release-20-prepare.sh
+++ b/scripts/release-20-prepare.sh
@@ -17,7 +17,8 @@ THIS_DIR="$(dirname "$(realpath "$0")")"
 [[ -z "${NUGET_PUBLISH_API_KEY+x}" ]] && >&2 echo "NUGET_PUBLISH_API_KEY is not set" && exit 2
 
 DIRS=(
-publish-nuget
+publish-common-nuget
+publish-aspire-nuget
 )
 RETURN=0
 

--- a/scripts/release-31-publish-nuget.sh
+++ b/scripts/release-31-publish-nuget.sh
@@ -14,5 +14,5 @@ THIS_DIR="$(dirname "$(realpath "$0")")"
 #| `stderr`         | Can be used for logging.
 
 # calling shared function from common-publish.sh
-publish_nuget "Hosting.Extensions.1Password" "publish-nuget"
-publish_nuget "Aspire.Hosting.Extensions.1Password" "publish-nuget"
+publish_nuget "Hosting.Extensions.1Password" "publish-common-nuget"
+publish_nuget "Aspire.Hosting.Extensions.1Password" "publish-aspire-nuget"

--- a/src/Aspire.Hosting.Extensions.1Password/Aspire.Hosting.Extensions.1Password.csproj
+++ b/src/Aspire.Hosting.Extensions.1Password/Aspire.Hosting.Extensions.1Password.csproj
@@ -40,4 +40,10 @@
       <PackageReference Include="Aspire.Hosting" />
     </ItemGroup>
 
+    <ItemGroup>
+      <!-- Exclude auto-generated files from NuGet package to avoid conflicts with multi-targeting -->
+      <Content Remove="$(IntermediateOutputPath)**\*.GlobalUsings.g.cs" />
+      <None Remove="$(IntermediateOutputPath)**\*.GlobalUsings.g.cs" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixes the build issue from [this](https://github.com/ArkanisCorporation/Hosting.Extensions.1Password/actions/runs/22233498672/job/64319187774) CI job:

```
Error: /usr/share/dotnet/sdk/10.0.103/NuGet.Build.Tasks.Pack.targets(222,5): error NU5118: Warning As Error: File '/home/runner/work/Hosting.Extensions.1Password/Hosting.Extensions.1Password/artifacts/obj/Aspire.Hosting.Extensions.1Password/release_net8.0/Aspire.Hosting.Extensions.1Password.GlobalUsings.g.cs' is not added because the package already contains file 'src/Aspire.Hosting.Extensions.1Password/Aspire.Hosting.Extensions.1Password.GlobalUsings.g.cs' [/home/runner/work/Hosting.Extensions.1Password/Hosting.Extensions.1Password/src/Aspire.Hosting.Extensions.1Password/Aspire.Hosting.Extensions.1Password.csproj]
Error: /usr/share/dotnet/sdk/10.0.103/NuGet.Build.Tasks.Pack.targets(222,5): error NU5118: Warning As Error: File '/home/runner/work/Hosting.Extensions.1Password/Hosting.Extensions.1Password/artifacts/obj/Aspire.Hosting.Extensions.1Password/release_net9.0/Aspire.Hosting.Extensions.1Password.GlobalUsings.g.cs' is not added because the package already contains file 'src/Aspire.Hosting.Extensions.1Password/Aspire.Hosting.Extensions.1Password.GlobalUsings.g.cs' [/home/runner/work/Hosting.Extensions.1Password/Hosting.Extensions.1Password/src/Aspire.Hosting.Extensions.1Password/Aspire.Hosting.Extensions.1Password.csproj]
```