### PR TITLE
build!: multi-target net8.0/9.0/10.0, drop netstandard2.1

### DIFF
--- a/src/Hosting.Extensions.1Password/Hosting.Extensions.1Password.csproj
+++ b/src/Hosting.Extensions.1Password/Hosting.Extensions.1Password.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
         <RootNamespace>Arkanis.Hosting.Extensions._1Password</RootNamespace>
         <AssemblyName>Arkanis.Hosting.Extensions.1Password</AssemblyName>
         <PackageId>Arkanis.Hosting.Extensions.1Password</PackageId>
@@ -10,6 +9,7 @@
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>
+        <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -18,7 +18,7 @@
         <!--<ImplicitUsings>disable</ImplicitUsings>-->
         <Nullable>enable</Nullable>
         <!-- Highest LangVersion supported by netstandard2.1 -->
-        <LangVersion>8</LangVersion>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Hosting.Extensions.1Password/IOnePasswordResponseParser.cs
+++ b/src/Hosting.Extensions.1Password/IOnePasswordResponseParser.cs
@@ -1,27 +1,26 @@
-namespace Arkanis.Hosting.Extensions._1Password
+namespace Arkanis.Hosting.Extensions._1Password;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// Defines an interface for parsing responses from the 1Password CLI.
+/// </summary>
+public interface IOnePasswordResponseParser
 {
-    using System.Collections.Generic;
+    /// <summary>
+    /// Creates a result template string from a key-value pair for use with the 1Password CLI.
+    /// </summary>
+    /// <param name="pair">The key-value pair to create a template for.</param>
+    /// <returns>A formatted template string for the 1Password CLI.</returns>
+    public string CreateResultTemplate(KeyValuePair<string, string> pair);
 
     /// <summary>
-    /// Defines an interface for parsing responses from the 1Password CLI.
+    /// Parses a result string from the 1Password CLI output.
     /// </summary>
-    public interface IOnePasswordResponseParser
-    {
-        /// <summary>
-        /// Creates a result template string from a key-value pair for use with the 1Password CLI.
-        /// </summary>
-        /// <param name="pair">The key-value pair to create a template for.</param>
-        /// <returns>A formatted template string for the 1Password CLI.</returns>
-        public string CreateResultTemplate(KeyValuePair<string, string> pair);
-
-        /// <summary>
-        /// Parses a result string from the 1Password CLI output.
-        /// </summary>
-        /// <param name="source">The output string from the 1Password CLI to parse.</param>
-        /// <returns>A key-value pair parsed from the source, or null if parsing fails.</returns>
-        /// <exception cref="OnePasswordResultException">
-        /// Thrown when the source string cannot be parsed into a valid key-value pair and silent failure is not requested.
-        /// </exception>
-        public KeyValuePair<string, string>? ParseResult(string source);
-    }
+    /// <param name="source">The output string from the 1Password CLI to parse.</param>
+    /// <returns>A key-value pair parsed from the source, or null if parsing fails.</returns>
+    /// <exception cref="OnePasswordResultException">
+    /// Thrown when the source string cannot be parsed into a valid key-value pair and silent failure is not requested.
+    /// </exception>
+    public KeyValuePair<string, string>? ParseResult(string source);
 }

--- a/src/Hosting.Extensions.1Password/IOpCliInvoker.cs
+++ b/src/Hosting.Extensions.1Password/IOpCliInvoker.cs
@@ -1,19 +1,18 @@
-namespace Arkanis.Hosting.Extensions._1Password
-{
-    using System.Threading.Tasks;
-    using CliWrap.Buffered;
+namespace Arkanis.Hosting.Extensions._1Password;
 
+using System.Threading.Tasks;
+using CliWrap.Buffered;
+
+/// <summary>
+/// Interface for invoking the 1Password CLI.
+/// </summary>
+public interface IOpCliInvoker
+{
     /// <summary>
-    /// Interface for invoking the 1Password CLI.
+    /// Invokes the 1Password CLI to inject secrets into the provided template.
     /// </summary>
-    public interface IOpCliInvoker
-    {
-        /// <summary>
-        /// Invokes the 1Password CLI to inject secrets into the provided template.
-        /// </summary>
-        /// <param name="account">The 1Password account or sign-in address to pass to the `op` CLI.</param>
-        /// <param name="opTemplate">The template containing 1Password secret references to inject.</param>
-        /// <returns>The buffered result from executing the CLI command.</returns>
-        public Task<BufferedCommandResult> InvokeAsync(string? account, string opTemplate);
-    }
+    /// <param name="account">The 1Password account or sign-in address to pass to the `op` CLI.</param>
+    /// <param name="opTemplate">The template containing 1Password secret references to inject.</param>
+    /// <returns>The buffered result from executing the CLI command.</returns>
+    public Task<BufferedCommandResult> InvokeAsync(string? account, string opTemplate);
 }

--- a/src/Hosting.Extensions.1Password/OnePasswordCliException.cs
+++ b/src/Hosting.Extensions.1Password/OnePasswordCliException.cs
@@ -1,49 +1,48 @@
-namespace Arkanis.Hosting.Extensions._1Password
+namespace Arkanis.Hosting.Extensions._1Password;
+
+using System;
+using JetBrains.Annotations;
+
+/// <summary>
+/// Exception thrown when 1Password CLI operations fail.
+/// </summary>
+[PublicAPI]
+public class OnePasswordCliException : OnePasswordException
 {
-    using System;
-    using JetBrains.Annotations;
+    /// <summary>
+    /// Gets the exit code returned by the 1Password CLI.
+    /// </summary>
+    public int ExitCode { get; }
 
     /// <summary>
-    /// Exception thrown when 1Password CLI operations fail.
+    /// Gets the standard error output from the 1Password CLI.
     /// </summary>
-    [PublicAPI]
-    public class OnePasswordCliException : OnePasswordException
+    public string StandardError { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OnePasswordCliException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="exitCode">The exit code from the 1Password CLI.</param>
+    /// <param name="standardError">The standard error output from the CLI.</param>
+    public OnePasswordCliException(string message, int exitCode, string standardError)
+        : base(message)
     {
-        /// <summary>
-        /// Gets the exit code returned by the 1Password CLI.
-        /// </summary>
-        public int ExitCode { get; }
+        ExitCode = exitCode;
+        StandardError = standardError;
+    }
 
-        /// <summary>
-        /// Gets the standard error output from the 1Password CLI.
-        /// </summary>
-        public string StandardError { get; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OnePasswordCliException"/> class.
-        /// </summary>
-        /// <param name="message">The error message.</param>
-        /// <param name="exitCode">The exit code from the 1Password CLI.</param>
-        /// <param name="standardError">The standard error output from the CLI.</param>
-        public OnePasswordCliException(string message, int exitCode, string standardError)
-            : base(message)
-        {
-            ExitCode = exitCode;
-            StandardError = standardError;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OnePasswordCliException"/> class.
-        /// </summary>
-        /// <param name="message">The error message.</param>
-        /// <param name="exitCode">The exit code from the 1Password CLI.</param>
-        /// <param name="standardError">The standard error output from the CLI.</param>
-        /// <param name="innerException">The inner exception.</param>
-        public OnePasswordCliException(string message, int exitCode, string standardError, Exception innerException)
-            : base(message, innerException)
-        {
-            ExitCode = exitCode;
-            StandardError = standardError;
-        }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OnePasswordCliException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="exitCode">The exit code from the 1Password CLI.</param>
+    /// <param name="standardError">The standard error output from the CLI.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public OnePasswordCliException(string message, int exitCode, string standardError, Exception innerException)
+        : base(message, innerException)
+    {
+        ExitCode = exitCode;
+        StandardError = standardError;
     }
 }

--- a/src/Hosting.Extensions.1Password/OnePasswordException.cs
+++ b/src/Hosting.Extensions.1Password/OnePasswordException.cs
@@ -1,35 +1,34 @@
-namespace Arkanis.Hosting.Extensions._1Password
+namespace Arkanis.Hosting.Extensions._1Password;
+
+using System;
+using JetBrains.Annotations;
+
+/// <summary>
+/// Exception thrown when an operation with 1Password fails.
+/// </summary>
+/// <remarks>
+/// This is a general base exception for all errors related to 1Password operations.
+/// You can catch this exception to handle any 1Password-related errors in a generic way.
+/// </remarks>
+[PublicAPI]
+public class OnePasswordException : Exception
 {
-    using System;
-    using JetBrains.Annotations;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OnePasswordException"/> class with the specified message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public OnePasswordException(string message)
+        : base(message)
+    {
+    }
 
     /// <summary>
-    /// Exception thrown when an operation with 1Password fails.
+    /// Initializes a new instance of the <see cref="OnePasswordException"/> class with the specified message and inner exception.
     /// </summary>
-    /// <remarks>
-    /// This is a general base exception for all errors related to 1Password operations.
-    /// You can catch this exception to handle any 1Password-related errors in a generic way.
-    /// </remarks>
-    [PublicAPI]
-    public class OnePasswordException : Exception
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public OnePasswordException(string message, Exception innerException)
+        : base(message, innerException)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OnePasswordException"/> class with the specified message.
-        /// </summary>
-        /// <param name="message">The message that describes the error.</param>
-        public OnePasswordException(string message)
-            : base(message)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OnePasswordException"/> class with the specified message and inner exception.
-        /// </summary>
-        /// <param name="message">The message that describes the error.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception.</param>
-        public OnePasswordException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
     }
 }

--- a/src/Hosting.Extensions.1Password/OnePasswordHelper.cs
+++ b/src/Hosting.Extensions.1Password/OnePasswordHelper.cs
@@ -1,146 +1,145 @@
-namespace Arkanis.Hosting.Extensions._1Password
+namespace Arkanis.Hosting.Extensions._1Password;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CliWrap.Buffered;
+using Microsoft.Extensions.Configuration;
+
+
+internal static class OnePasswordHelper
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading.Tasks;
-    using CliWrap.Buffered;
-    using Microsoft.Extensions.Configuration;
+    /// <summary>
+    ///     Internal factory for creating IOpCliInvoker instances. Used for testing.
+    /// </summary>
+    internal static Func<IOpCliInvoker>? InvokerFactory { get; set; }
 
-
-    internal static class OnePasswordHelper
+    public static async Task Replace1PasswordConfigurationItems(Dictionary<string, IConfigurationSection> opSections, OnePasswordOptions options)
     {
-        /// <summary>
-        ///     Internal factory for creating IOpCliInvoker instances. Used for testing.
-        /// </summary>
-        internal static Func<IOpCliInvoker>? InvokerFactory { get; set; }
+        var parser = GetResponseParser(options);
+        var opTemplate = string.Join(
+            "\n",
+            opSections.Values
+                .Select(section => KeyValuePair.Create(section.Path, section.Value ?? string.Empty))
+                .Select(parser.CreateResultTemplate)
+        );
 
-        public static async Task Replace1PasswordConfigurationItems(Dictionary<string, IConfigurationSection> opSections, OnePasswordOptions options)
+        try
         {
-            var parser = GetResponseParser(options);
-            var opTemplate = string.Join(
-                "\n",
-                opSections.Values
-                    .Select(section => KeyValuePair.Create(section.Path, section.Value ?? string.Empty))
-                    .Select(parser.CreateResultTemplate)
-            );
+            var invoker = GetCliInvoker(options);
+            var result = await invoker.InvokeAsync(options.Account, opTemplate);
+            ValidateInvokerResult(result, options);
 
-            try
+            foreach (var pair in ProcessResults(result, parser))
             {
-                var invoker = GetCliInvoker(options);
-                var result = await invoker.InvokeAsync(options.Account, opTemplate);
-                ValidateInvokerResult(result, options);
-
-                foreach (var pair in ProcessResults(result, parser))
+                // Only update if the key exists in our sections dictionary
+                if (opSections.TryGetValue(pair.Key, out var section))
                 {
-                    // Only update if the key exists in our sections dictionary
-                    if (opSections.TryGetValue(pair.Key, out var section))
-                    {
-                        section.Value = pair.Value;
-                    }
+                    section.Value = pair.Value;
                 }
             }
-            catch (OnePasswordException)
+        }
+        catch (OnePasswordException)
+        {
+            // pass through known exceptions related to 1Password operations without wrapping
+            throw;
+        }
+        catch (Exception e)
+        {
+            // wrap any other exceptions that occur during invocation or processing in a OnePasswordException
+            throw new OnePasswordException("Failed to invoke and process results", e);
+        }
+    }
+
+    public static async Task<string> Resolve1PasswordItem(string key, OnePasswordOptions options)
+    {
+        const string resultKey = "VALUE";
+
+        var parser = GetResponseParser(options);
+        var template = parser.CreateResultTemplate(KeyValuePair.Create(resultKey, key));
+
+        try
+        {
+            var invoker = GetCliInvoker(options);
+            var result = await invoker.InvokeAsync(options.Account, template);
+            ValidateInvokerResult(result, options);
+
+            return ProcessResults(result, parser)
+                .Single(x => x.Key == resultKey)
+                .Value;
+        }
+        catch (OnePasswordException)
+        {
+            // pass through known exceptions related to 1Password operations without wrapping
+            throw;
+        }
+        catch (Exception e)
+        {
+            // wrap any other exceptions that occur during invocation or processing in a OnePasswordException
+            throw new OnePasswordException("Failed to invoke and process results", e);
+        }
+    }
+
+    private static IEnumerable<KeyValuePair<string, string>> ProcessResults(BufferedCommandResult result, IOnePasswordResponseParser parser)
+    {
+        foreach (var line in result.StandardOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!(parser.ParseResult(line) is { } pair))
             {
-                // pass through known exceptions related to 1Password operations without wrapping
-                throw;
+                continue;
             }
-            catch (Exception e)
-            {
-                // wrap any other exceptions that occur during invocation or processing in a OnePasswordException
-                throw new OnePasswordException("Failed to invoke and process results", e);
-            }
+
+            yield return pair;
+        }
+    }
+
+    private static void ValidateInvokerResult(BufferedCommandResult result, OnePasswordOptions options)
+    {
+        if (result.IsSuccess || options.FailSilently)
+        {
+            return;
         }
 
-        public static async Task<string> Resolve1PasswordItem(string key, OnePasswordOptions options)
+        throw new OnePasswordCliException(
+            "Failed to resolve secrets from 1Password. "
+            + "Ensure the 1Password CLI ('op') is installed and you are authenticated. "
+            + "Run 'op signin' to authenticate or check 'op --version' to verify installation."
+            + $"\nSTDERR:\n{result.StandardError}",
+            result.ExitCode,
+            result.StandardError
+        );
+    }
+
+    private static IOpCliInvoker GetCliInvoker(OnePasswordOptions options)
+        => options.CliInvoker ?? InvokerFactory?.Invoke() ?? new OpCliInvoker();
+
+    private static IOnePasswordResponseParser GetResponseParser(OnePasswordOptions options)
+        => options.ResponseParser ?? new OnePasswordResponseParser(options);
+
+    public static Dictionary<string, IConfigurationSection> GetOpConfigurationSections(
+        IConfigurationManager configurationManager,
+        OnePasswordOptions options
+    )
+    {
+        var sections = new Queue<IConfigurationSection>(configurationManager.GetChildren());
+        var opSections = new Dictionary<string, IConfigurationSection>();
+
+        while (sections.TryDequeue(out var section))
         {
-            const string resultKey = "VALUE";
-
-            var parser = GetResponseParser(options);
-            var template = parser.CreateResultTemplate(KeyValuePair.Create(resultKey, key));
-
-            try
+            if (section.Value is { } s && s.StartsWith(options.ConfigurationSectionItemSchema, StringComparison.OrdinalIgnoreCase))
             {
-                var invoker = GetCliInvoker(options);
-                var result = await invoker.InvokeAsync(options.Account, template);
-                ValidateInvokerResult(result, options);
-
-                return ProcessResults(result, parser)
-                    .Single(x => x.Key == resultKey)
-                    .Value;
+                opSections.Add(section.Path, section);
             }
-            catch (OnePasswordException)
+            else
             {
-                // pass through known exceptions related to 1Password operations without wrapping
-                throw;
-            }
-            catch (Exception e)
-            {
-                // wrap any other exceptions that occur during invocation or processing in a OnePasswordException
-                throw new OnePasswordException("Failed to invoke and process results", e);
-            }
-        }
-
-        private static IEnumerable<KeyValuePair<string, string>> ProcessResults(BufferedCommandResult result, IOnePasswordResponseParser parser)
-        {
-            foreach (var line in result.StandardOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries))
-            {
-                if (!(parser.ParseResult(line) is { } pair))
+                foreach (var child in section.GetChildren())
                 {
-                    continue;
+                    sections.Enqueue(child);
                 }
-
-                yield return pair;
             }
         }
 
-        private static void ValidateInvokerResult(BufferedCommandResult result, OnePasswordOptions options)
-        {
-            if (result.IsSuccess || options.FailSilently)
-            {
-                return;
-            }
-
-            throw new OnePasswordCliException(
-                "Failed to resolve secrets from 1Password. "
-                + "Ensure the 1Password CLI ('op') is installed and you are authenticated. "
-                + "Run 'op signin' to authenticate or check 'op --version' to verify installation."
-                + $"\nSTDERR:\n{result.StandardError}",
-                result.ExitCode,
-                result.StandardError
-            );
-        }
-
-        private static IOpCliInvoker GetCliInvoker(OnePasswordOptions options)
-            => options.CliInvoker ?? InvokerFactory?.Invoke() ?? new OpCliInvoker();
-
-        private static IOnePasswordResponseParser GetResponseParser(OnePasswordOptions options)
-            => options.ResponseParser ?? new OnePasswordResponseParser(options);
-
-        public static Dictionary<string, IConfigurationSection> GetOpConfigurationSections(
-            IConfigurationManager configurationManager,
-            OnePasswordOptions options
-        )
-        {
-            var sections = new Queue<IConfigurationSection>(configurationManager.GetChildren());
-            var opSections = new Dictionary<string, IConfigurationSection>();
-
-            while (sections.TryDequeue(out var section))
-            {
-                if (section.Value is { } s && s.StartsWith(options.ConfigurationSectionItemSchema, StringComparison.OrdinalIgnoreCase))
-                {
-                    opSections.Add(section.Path, section);
-                }
-                else
-                {
-                    foreach (var child in section.GetChildren())
-                    {
-                        sections.Enqueue(child);
-                    }
-                }
-            }
-
-            return opSections;
-        }
+        return opSections;
     }
 }

--- a/src/Hosting.Extensions.1Password/OnePasswordHostingExtension.cs
+++ b/src/Hosting.Extensions.1Password/OnePasswordHostingExtension.cs
@@ -1,71 +1,70 @@
-﻿namespace Arkanis.Hosting.Extensions._1Password
+﻿namespace Arkanis.Hosting.Extensions._1Password;
+
+using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// Extension methods for integrating 1Password with IHostApplicationBuilder.
+/// </summary>
+public static class OnePasswordHostingExtension
 {
-    using System;
-    using System.Threading.Tasks;
-    using JetBrains.Annotations;
-    using Microsoft.Extensions.Hosting;
+    /// <summary>
+    /// Uses 1Password to inject secrets into the application's configuration.
+    /// Automatically detects configuration entries that reference 1Password secrets
+    /// using the "op://" URI scheme and replaces them with the actual secret values.
+    /// </summary>
+    /// <param name="builder">The host application builder.</param>
+    /// <param name="account">The 1Password account or sign-in address to pass to the `op` CLI.</param>
+    /// <param name="failSilently">
+    /// If true, CLI failures and malformed output will be silently ignored and op:// references remain unchanged.
+    /// If false (default), throws <see cref="OnePasswordCliException"/> on CLI errors or malformed output.
+    /// </param>
+    /// <returns>The host application builder for chaining.</returns>
+    /// <exception cref="OnePasswordException">
+    /// Thrown when the 1Password CLI fails or returns malformed output, and <paramref name="failSilently"/> is false.
+    /// </exception>
+    [PublicAPI]
+    public static async Task<IHostApplicationBuilder> Use1PasswordAsync(this IHostApplicationBuilder builder, string? account = null, bool failSilently = false)
+        => await builder.Use1PasswordAsync(options =>
+        {
+            options.Account = account;
+            options.FailSilently = failSilently;
+        });
 
     /// <summary>
-    /// Extension methods for integrating 1Password with IHostApplicationBuilder.
+    /// Uses 1Password to inject secrets into the application's configuration.
+    /// Automatically detects configuration entries that reference 1Password secrets
+    /// using the "op://" URI scheme and replaces them with the actual secret values.
     /// </summary>
-    public static class OnePasswordHostingExtension
+    /// <param name="builder">The host application builder.</param>
+    /// <param name="configureOptions">An action to configure 1Password options such as account and error handling behavior.</param>
+    /// <returns>The host application builder for chaining.</returns>
+    /// <exception cref="OnePasswordException">Thrown when the 1Password CLI fails or returns malformed output, and failSilently is false.</exception>
+    [PublicAPI]
+    public static async Task<IHostApplicationBuilder> Use1PasswordAsync(this IHostApplicationBuilder builder, Action<OnePasswordOptions> configureOptions)
     {
-        /// <summary>
-        /// Uses 1Password to inject secrets into the application's configuration.
-        /// Automatically detects configuration entries that reference 1Password secrets
-        /// using the "op://" URI scheme and replaces them with the actual secret values.
-        /// </summary>
-        /// <param name="builder">The host application builder.</param>
-        /// <param name="account">The 1Password account or sign-in address to pass to the `op` CLI.</param>
-        /// <param name="failSilently">
-        /// If true, CLI failures and malformed output will be silently ignored and op:// references remain unchanged.
-        /// If false (default), throws <see cref="OnePasswordCliException"/> on CLI errors or malformed output.
-        /// </param>
-        /// <returns>The host application builder for chaining.</returns>
-        /// <exception cref="OnePasswordException">
-        /// Thrown when the 1Password CLI fails or returns malformed output, and <paramref name="failSilently"/> is false.
-        /// </exception>
-        [PublicAPI]
-        public static async Task<IHostApplicationBuilder> Use1PasswordAsync(this IHostApplicationBuilder builder, string? account = null, bool failSilently = false)
-            => await builder.Use1PasswordAsync(options =>
-            {
-                options.Account = account;
-                options.FailSilently = failSilently;
-            });
+        var options = new OnePasswordOptions();
+        configureOptions(options);
 
-        /// <summary>
-        /// Uses 1Password to inject secrets into the application's configuration.
-        /// Automatically detects configuration entries that reference 1Password secrets
-        /// using the "op://" URI scheme and replaces them with the actual secret values.
-        /// </summary>
-        /// <param name="builder">The host application builder.</param>
-        /// <param name="configureOptions">An action to configure 1Password options such as account and error handling behavior.</param>
-        /// <returns>The host application builder for chaining.</returns>
-        /// <exception cref="OnePasswordException">Thrown when the 1Password CLI fails or returns malformed output, and failSilently is false.</exception>
-        [PublicAPI]
-        public static async Task<IHostApplicationBuilder> Use1PasswordAsync(this IHostApplicationBuilder builder, Action<OnePasswordOptions> configureOptions)
+        var opSections = OnePasswordHelper.GetOpConfigurationSections(builder.Configuration, options);
+        if (opSections.Count == 0)
         {
-            var options = new OnePasswordOptions();
-            configureOptions(options);
-
-            var opSections = OnePasswordHelper.GetOpConfigurationSections(builder.Configuration, options);
-            if (opSections.Count == 0)
-            {
-                return builder;
-            }
-
-            await OnePasswordHelper.Replace1PasswordConfigurationItems(opSections, options);
             return builder;
         }
 
-        /// <inheritdoc cref="Use1PasswordAsync(IHostApplicationBuilder,string,bool)" />
-        [PublicAPI]
-        public static IHostApplicationBuilder Use1Password(this IHostApplicationBuilder builder, string? account = null, bool failSilently = false)
-            => builder.Use1PasswordAsync(account: account, failSilently: failSilently).GetAwaiter().GetResult();
-
-        /// <inheritdoc cref="Use1PasswordAsync(IHostApplicationBuilder,Action{OnePasswordOptions})" />
-        [PublicAPI]
-        public static IHostApplicationBuilder Use1Password(this IHostApplicationBuilder builder, Action<OnePasswordOptions> configureOptions)
-            => builder.Use1PasswordAsync(configureOptions: configureOptions).GetAwaiter().GetResult();
+        await OnePasswordHelper.Replace1PasswordConfigurationItems(opSections, options);
+        return builder;
     }
+
+    /// <inheritdoc cref="Use1PasswordAsync(IHostApplicationBuilder,string,bool)" />
+    [PublicAPI]
+    public static IHostApplicationBuilder Use1Password(this IHostApplicationBuilder builder, string? account = null, bool failSilently = false)
+        => builder.Use1PasswordAsync(account: account, failSilently: failSilently).GetAwaiter().GetResult();
+
+    /// <inheritdoc cref="Use1PasswordAsync(IHostApplicationBuilder,Action{OnePasswordOptions})" />
+    [PublicAPI]
+    public static IHostApplicationBuilder Use1Password(this IHostApplicationBuilder builder, Action<OnePasswordOptions> configureOptions)
+        => builder.Use1PasswordAsync(configureOptions: configureOptions).GetAwaiter().GetResult();
 }

--- a/src/Hosting.Extensions.1Password/OnePasswordOptions.cs
+++ b/src/Hosting.Extensions.1Password/OnePasswordOptions.cs
@@ -1,56 +1,55 @@
-namespace Arkanis.Hosting.Extensions._1Password
+namespace Arkanis.Hosting.Extensions._1Password;
+
+using JetBrains.Annotations;
+
+/// <summary>
+/// Configuration options for 1Password integration.
+/// </summary>
+public class OnePasswordOptions
 {
-    using JetBrains.Annotations;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OnePasswordOptions"/> class with default values.
+    /// </summary>
+    public OnePasswordOptions()
+    {
+    }
 
     /// <summary>
-    /// Configuration options for 1Password integration.
+    /// Initializes a new instance of the <see cref="OnePasswordOptions"/> class by copying values from another instance.
     /// </summary>
-    public class OnePasswordOptions
+    /// <param name="options">The options instance to copy from.</param>
+    [PublicAPI]
+    public OnePasswordOptions(OnePasswordOptions options)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OnePasswordOptions"/> class with default values.
-        /// </summary>
-        public OnePasswordOptions()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OnePasswordOptions"/> class by copying values from another instance.
-        /// </summary>
-        /// <param name="options">The options instance to copy from.</param>
-        [PublicAPI]
-        public OnePasswordOptions(OnePasswordOptions options)
-        {
-            CliInvoker = options.CliInvoker;
-            ResponseParser = options.ResponseParser;
-            ConfigurationSectionItemSchema = options.ConfigurationSectionItemSchema;
-            Account = options.Account;
-            FailSilently = options.FailSilently;
-        }
-
-        /// <summary>
-        /// Gets or sets the CLI invoker to use for executing 1Password CLI commands.
-        /// </summary>
-        public IOpCliInvoker? CliInvoker { get; set; }
-
-        /// <summary>
-        /// Gets or sets the response parser to use for parsing 1Password CLI output.
-        /// </summary>
-        public IOnePasswordResponseParser? ResponseParser { get; set; }
-
-        /// <summary>
-        /// Gets or sets the schema prefix used to identify 1Password secret references in configuration (default: "op://").
-        /// </summary>
-        public string ConfigurationSectionItemSchema { get; set; } = "op://";
-
-        /// <summary>
-        /// Gets or sets the 1Password account or sign-in address to use.
-        /// </summary>
-        public string? Account { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether failures should be silently ignored.
-        /// </summary>
-        public bool FailSilently { get; set; }
+        CliInvoker = options.CliInvoker;
+        ResponseParser = options.ResponseParser;
+        ConfigurationSectionItemSchema = options.ConfigurationSectionItemSchema;
+        Account = options.Account;
+        FailSilently = options.FailSilently;
     }
+
+    /// <summary>
+    /// Gets or sets the CLI invoker to use for executing 1Password CLI commands.
+    /// </summary>
+    public IOpCliInvoker? CliInvoker { get; set; }
+
+    /// <summary>
+    /// Gets or sets the response parser to use for parsing 1Password CLI output.
+    /// </summary>
+    public IOnePasswordResponseParser? ResponseParser { get; set; }
+
+    /// <summary>
+    /// Gets or sets the schema prefix used to identify 1Password secret references in configuration (default: "op://").
+    /// </summary>
+    public string ConfigurationSectionItemSchema { get; set; } = "op://";
+
+    /// <summary>
+    /// Gets or sets the 1Password account or sign-in address to use.
+    /// </summary>
+    public string? Account { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether failures should be silently ignored.
+    /// </summary>
+    public bool FailSilently { get; set; }
 }

--- a/src/Hosting.Extensions.1Password/OnePasswordResponseParser.cs
+++ b/src/Hosting.Extensions.1Password/OnePasswordResponseParser.cs
@@ -1,68 +1,67 @@
-namespace Arkanis.Hosting.Extensions._1Password
+namespace Arkanis.Hosting.Extensions._1Password;
+
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Default implementation of <see cref="IOnePasswordResponseParser"/> for parsing 1Password CLI responses.
+/// </summary>
+public class OnePasswordResponseParser : IOnePasswordResponseParser
 {
-    using System;
-    using System.Collections.Generic;
+    private readonly OnePasswordOptions _options;
 
     /// <summary>
-    /// Default implementation of <see cref="IOnePasswordResponseParser"/> for parsing 1Password CLI responses.
+    /// Initializes a new instance of the <see cref="OnePasswordResponseParser"/> class.
     /// </summary>
-    public class OnePasswordResponseParser : IOnePasswordResponseParser
+    /// <param name="options">The options to use for parsing.</param>
+    public OnePasswordResponseParser(OnePasswordOptions options)
+        => _options = options;
+
+    /// <summary>
+    /// Gets the separator character used between keys and values in the result format.
+    /// </summary>
+    protected const char Separator = '=';
+
+    /// <summary>
+    /// Creates a result template string from a key-value pair for use with the 1Password CLI.
+    /// </summary>
+    /// <param name="pair">The key-value pair to create a template for.</param>
+    /// <returns>A formatted template string (format: "key="value"").</returns>
+    public virtual string CreateResultTemplate(KeyValuePair<string, string> pair)
+        => $"{pair.Key}{Separator}\"{pair.Value}\"";
+
+    /// <summary>
+    /// Parses a result string from the 1Password CLI output.
+    /// </summary>
+    /// <param name="source">The output string from the 1Password CLI to parse.</param>
+    /// <returns>A key-value pair parsed from the source, or null if parsing fails silently.</returns>
+    /// <exception cref="OnePasswordResultException">Thrown when the output format is invalid and silent failure is disabled.</exception>
+    public KeyValuePair<string, string>? ParseResult(string source)
     {
-        private readonly OnePasswordOptions _options;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OnePasswordResponseParser"/> class.
-        /// </summary>
-        /// <param name="options">The options to use for parsing.</param>
-        public OnePasswordResponseParser(OnePasswordOptions options)
-            => _options = options;
-
-        /// <summary>
-        /// Gets the separator character used between keys and values in the result format.
-        /// </summary>
-        protected const char Separator = '=';
-
-        /// <summary>
-        /// Creates a result template string from a key-value pair for use with the 1Password CLI.
-        /// </summary>
-        /// <param name="pair">The key-value pair to create a template for.</param>
-        /// <returns>A formatted template string (format: "key="value"").</returns>
-        public virtual string CreateResultTemplate(KeyValuePair<string, string> pair)
-            => $"{pair.Key}{Separator}\"{pair.Value}\"";
-
-        /// <summary>
-        /// Parses a result string from the 1Password CLI output.
-        /// </summary>
-        /// <param name="source">The output string from the 1Password CLI to parse.</param>
-        /// <returns>A key-value pair parsed from the source, or null if parsing fails silently.</returns>
-        /// <exception cref="OnePasswordResultException">Thrown when the output format is invalid and silent failure is disabled.</exception>
-        public KeyValuePair<string, string>? ParseResult(string source)
+        // Split into max 2 parts to handle values containing "="
+        var sourceSpan = source.AsSpan();
+        var separatorIndex = sourceSpan.IndexOf(Separator);
+        if (separatorIndex == -1)
         {
-            // Split into max 2 parts to handle values containing "="
-            var sourceSpan = source.AsSpan();
-            var separatorIndex = sourceSpan.IndexOf(Separator);
-            if (separatorIndex == -1)
+            if (_options.FailSilently)
             {
-                if (_options.FailSilently)
-                {
-                    // Skip malformed lines when silent failure is enabled
-                    return null;
-                }
-
-                var expectedFormat = CreateResultTemplate(KeyValuePair.Create<string, string>("key", "value"));
-                throw new OnePasswordResultException($"Received malformed output from 1Password CLI. Expected '{expectedFormat}' format but got: {source}");
+                // Skip malformed lines when silent failure is enabled
+                return null;
             }
 
-            var key = sourceSpan[..separatorIndex];
-            var value = sourceSpan[(separatorIndex + 1)..];
-
-            // Remove surrounding quotes if present
-            if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
-            {
-                value = value[1..^1];
-            }
-
-            return KeyValuePair.Create(key.ToString(), value.ToString());
+            var expectedFormat = CreateResultTemplate(KeyValuePair.Create<string, string>("key", "value"));
+            throw new OnePasswordResultException($"Received malformed output from 1Password CLI. Expected '{expectedFormat}' format but got: {source}");
         }
+
+        var key = sourceSpan[..separatorIndex];
+        var value = sourceSpan[(separatorIndex + 1)..];
+
+        // Remove surrounding quotes if present
+        if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+        {
+            value = value[1..^1];
+        }
+
+        return KeyValuePair.Create(key.ToString(), value.ToString());
     }
 }

--- a/src/Hosting.Extensions.1Password/OnePasswordResultException.cs
+++ b/src/Hosting.Extensions.1Password/OnePasswordResultException.cs
@@ -1,31 +1,30 @@
-namespace Arkanis.Hosting.Extensions._1Password
+namespace Arkanis.Hosting.Extensions._1Password;
+
+using System;
+using JetBrains.Annotations;
+
+/// <summary>
+/// Exception thrown when the 1Password CLI returns a malformed result.
+/// </summary>
+[PublicAPI]
+public class OnePasswordResultException : OnePasswordException
 {
-    using System;
-    using JetBrains.Annotations;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OnePasswordResultException"/> class with the specified message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public OnePasswordResultException(string message)
+        : base(message)
+    {
+    }
 
     /// <summary>
-    /// Exception thrown when the 1Password CLI returns a malformed result.
+    /// Initializes a new instance of the <see cref="OnePasswordResultException"/> class with the specified message and inner exception.
     /// </summary>
-    [PublicAPI]
-    public class OnePasswordResultException : OnePasswordException
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public OnePasswordResultException(string message, Exception innerException)
+        : base(message, innerException)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OnePasswordResultException"/> class with the specified message.
-        /// </summary>
-        /// <param name="message">The message that describes the error.</param>
-        public OnePasswordResultException(string message)
-            : base(message)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OnePasswordResultException"/> class with the specified message and inner exception.
-        /// </summary>
-        /// <param name="message">The message that describes the error.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception.</param>
-        public OnePasswordResultException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
     }
 }

--- a/src/Hosting.Extensions.1Password/OpCliInvoker.cs
+++ b/src/Hosting.Extensions.1Password/OpCliInvoker.cs
@@ -1,28 +1,27 @@
-namespace Arkanis.Hosting.Extensions._1Password
+namespace Arkanis.Hosting.Extensions._1Password;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CliWrap;
+using CliWrap.Buffered;
+
+internal sealed class OpCliInvoker : IOpCliInvoker
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using CliWrap;
-    using CliWrap.Buffered;
-
-    internal sealed class OpCliInvoker : IOpCliInvoker
+    public async Task<BufferedCommandResult> InvokeAsync(string? account, string opTemplate)
     {
-        public async Task<BufferedCommandResult> InvokeAsync(string? account, string opTemplate)
+        var arguments = new List<string> { "inject" };
+        if (account is not null)
         {
-            var arguments = new List<string> { "inject" };
-            if (account is { })
-            {
-                arguments.Add("--account");
-                arguments.Add(account);
-            }
-
-            var result = await Cli.Wrap("op")
-                .WithStandardInputPipe(PipeSource.FromString(opTemplate))
-                .WithArguments(arguments, true)
-                .WithValidation(CommandResultValidation.None)
-                .ExecuteBufferedAsync();
-
-            return result;
+            arguments.Add("--account");
+            arguments.Add(account);
         }
+
+        var result = await Cli.Wrap("op")
+            .WithStandardInputPipe(PipeSource.FromString(opTemplate))
+            .WithArguments(arguments, true)
+            .WithValidation(CommandResultValidation.None)
+            .ExecuteBufferedAsync();
+
+        return result;
     }
 }

--- a/src/Hosting.Extensions.1Password/packages.lock.json
+++ b/src/Hosting.Extensions.1Password/packages.lock.json
@@ -1,15 +1,12 @@
 {
   "version": 2,
   "dependencies": {
-    ".NETStandard,Version=v2.1": {
+    "net10.0": {
       "CliWrap": {
         "type": "Direct",
         "requested": "[3.10.2, )",
         "resolved": "3.10.2",
-        "contentHash": "oW63Lh5Tr2dVRnGSn5UyV2ITAYTdyaGB8r4pGMcz7CwfzketV7ANyn2LvNJtOjXjL/tJbG0qDH8Xwgt3jgGMNg==",
-        "dependencies": {
-          "System.Management": "10.0.8"
-        }
+        "contentHash": "oW63Lh5Tr2dVRnGSn5UyV2ITAYTdyaGB8r4pGMcz7CwfzketV7ANyn2LvNJtOjXjL/tJbG0qDH8Xwgt3jgGMNg=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",
@@ -53,10 +50,316 @@
           "Microsoft.Extensions.Options": "10.0.9"
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces": {
+      "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.9",
-        "contentHash": "Aq7M8lG6BrHeatqKqncVm9m55ec34k6nnfPRLe/PvGg+b/pAsRM2ejofeKmCLjTXMa+5NGXm382f8CG/D5WDow=="
+        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "8D4HaqxWdm5M/nuhQffjPoR1ekhlpyKTXjFMAT5KlP0dvxkJe5JLAP6MAsuUEUxKWG09Bi5aAUaYMFKrMqWHqA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "JhKySWIL8+N4yFt4HPm1rGKCHooze+MBdTdpXc0bd/PGm31TrSUi2m0Nek1y441Wlv/RE6VH0W/DCv2xnmy8FA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "NgLB9cYnIb0/djSDcnqo4GIGGWooxGmr/gCUe3/CRXcKqLizOFui8MyW4EVkTB/KNJL+oXdMXnD6ZRm3Y+qkrQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "LiFKJgc9jZEW+7RhcSfsvCwoikt1lDdOqOn+whZC5zVHyg/gExftHl2QPtmfiHsEdDNg+Y+BDr6835tOfj8Y7A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "ockJRreRW/HbGwoyHzYOxMucFBimvAZ8lKNwQLMHrS6mwkDUaCJMWzzeE+Rm9vgFlv2o/xqk8fm+FpqrDCnkTA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Json": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "NijozhERJDIaJ4k5TSMy1jOi0cSC2HfkvRD/Sl+kGSSKgVbFnF4GxgtMN/MrzHB8D1JxIrD4xSer9Blh9v3axQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "NLXI3PbTe39q6/sgs7JYhmfPf7bMzReUoAJ0q9Po6yhfM+0anZa7PrEva4W2SdiLWGyB9eKZS9THGt2BP40xJg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "zm8WVod4swgprGrkxkuSILlbXqdDRqF+3y6U0I7jlmj4PMyKN6d8pzXZHUn5lr/gZVULzk/+FeTYlTupt6akpg==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "mvRf9qOH/LslWIee/h+lsElnoUyKotEwoPL31soqScmO/eoxObaTCLCdx2DdqPdRi9LnB+7qKZ49jfyrLZuc+w=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "N7Gm9SjugYjmmnhwbBKC9DFqGqjfJvh6YfOJgtwh0AW0Xpok3dIVors1ik050XmUxKAgAc7nNngDIJyFb06K2g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "bUth5ip7YsZMXWZS42IRTI0zDrPEqdE+xnsmcL0Pk784grWKApDvc5UoMi2tP2qYJ5ylFzeVDuDu08sFATq1bg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "WyZEG/O8jKqBOBF6/M6IJqiEyWFBUv6PDyzNoXDA0mBZwKtkuf7GiZ/0/8eU8OpLKKQL0O95oPOY1szrWIKofQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "r/A0ahpXmZH/8ltPjrFFWp12BIizK9cCVJXPcHyOad8e4eIX7P/geW+uBYdczkeCAaMebT4jEU7snOm4GnmKfA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "goAl30/WwmdnWDPRwATaDPIK0iuDBnQSMTH2XYGVB1SwReg7hglhvDNjjpNhT25US3GF4I5q6BhTNs6nFYzEfg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "System.Diagnostics.EventLog": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "tHynPVHbTicuaDpS2JVTxX0qA5VTg15CXgVKTwWvvudb5BvW5aVew8MMyek6LrDGAom7UbON1jf1T5GhpTilFA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Y4E24zffF/aPS0igNvY6ZzAQfbxd6AYdC9L4brnH+uK0yYYHIR6FeGVQVVjAOo8wub1EQDl2B90lCcpqoTF7Yw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "s2PcxHK4IYQ6gmD3VSBkym9tWGkFisKjcjWBdl7a+n4Yy66ae4beJ1ZdjDp060SSll4W3Rt4H2LW87dWckv+QQ=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "woZsWLhOQsASuxbmgiZJqiGUBNo3IjRdXC92xt8rRokza+P6/nIsnzq7sm9Or6ZYcRl2kL1ufj8HVzp1QlPTXw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "Tp/+LPb70RyjjtLg9m5C959eP4KrUpJHThZfAegZVpsfmGvzfuNkuYbI/ft+LvXhMSyUcAeOPaN6rzTccwnZAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      }
+    },
+    "net8.0": {
+      "CliWrap": {
+        "type": "Direct",
+        "requested": "[3.10.2, )",
+        "resolved": "3.10.2",
+        "contentHash": "oW63Lh5Tr2dVRnGSn5UyV2ITAYTdyaGB8r4pGMcz7CwfzketV7ANyn2LvNJtOjXjL/tJbG0qDH8Xwgt3jgGMNg=="
+      },
+      "DotNet.ReproducibleBuilds": {
+        "type": "Direct",
+        "requested": "[2.0.5, )",
+        "resolved": "2.0.5",
+        "contentHash": "8LrlvI1KpjjJ4VGSqZ16yoOCKlQnYS+Y8rYNifNrscmVh5anJcF9E4e0NiDP30BHBMUbkoJ5KdcxoRWM7Pz9Aw=="
+      },
+      "JetBrains.Annotations": {
+        "type": "Direct",
+        "requested": "[2026.2.0, )",
+        "resolved": "2026.2.0",
+        "contentHash": "drvAEaI7Xf4wU6dx4UTB9MoZWXZlraaQ0qoeThPQ411FxNhId7QdUTukIC9I8aUHP0ycAaGwZNKqSvfOZQvUlg=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Direct",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "HTgnvmK0ubesUFO16pLC+i9+RS8lEGd6TmDouuy75FsAgIFrSwUVhYCqG2IENzBJwgxGc/6Rsulfsvd9ZG/XkA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.9",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.9",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Json": "10.0.9",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.9",
+          "Microsoft.Extensions.Logging.Console": "10.0.9",
+          "Microsoft.Extensions.Logging.Debug": "10.0.9",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.9",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
@@ -167,8 +470,7 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "10.0.9",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9",
-          "System.Diagnostics.DiagnosticSource": "10.0.9"
+          "Microsoft.Extensions.Options": "10.0.9"
         }
       },
       "Microsoft.Extensions.Logging.Configuration": {
@@ -191,13 +493,11 @@
         "resolved": "10.0.9",
         "contentHash": "WyZEG/O8jKqBOBF6/M6IJqiEyWFBUv6PDyzNoXDA0mBZwKtkuf7GiZ/0/8eU8OpLKKQL0O95oPOY1szrWIKofQ==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.Logging": "10.0.9",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
           "Microsoft.Extensions.Logging.Configuration": "10.0.9",
           "Microsoft.Extensions.Options": "10.0.9",
-          "System.Buffers": "4.6.1",
           "System.Text.Json": "10.0.9"
         }
       },
@@ -228,14 +528,11 @@
         "resolved": "10.0.9",
         "contentHash": "tHynPVHbTicuaDpS2JVTxX0qA5VTg15CXgVKTwWvvudb5BvW5aVew8MMyek6LrDGAom7UbON1jf1T5GhpTilFA==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.Logging": "10.0.9",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
           "Microsoft.Extensions.Options": "10.0.9",
           "Microsoft.Extensions.Primitives": "10.0.9",
-          "System.Memory": "4.6.3",
-          "System.Runtime.CompilerServices.Unsafe": "6.1.2",
           "System.Text.Json": "10.0.9"
         }
       },
@@ -245,8 +542,7 @@
         "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Primitives": "10.0.9",
-          "System.ComponentModel.Annotations": "5.0.0"
+          "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
@@ -264,105 +560,36 @@
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
         "resolved": "10.0.9",
-        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g==",
-        "dependencies": {
-          "System.Memory": "4.6.3",
-          "System.Runtime.CompilerServices.Unsafe": "6.1.2"
-        }
-      },
-      "System.Buffers": {
-        "type": "Transitive",
-        "resolved": "4.6.1",
-        "contentHash": "N8GXpmiLMtljq7gwvyS+1QvKT/W2J8sNAvx+HVg4NGmsG/H+2k/y9QI23auLJRterrzCiDH+IWAw4V/GPwsMlw=="
-      },
-      "System.CodeDom": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "23AxxQYf5rjSmsawFw8kCVLRvvCIKMCnZWnRzBcHkzwsBra5eTv4k88BV6fEN+f3FVHO7PneZj3LOEyQnnPhTA=="
-      },
-      "System.ComponentModel.Annotations": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "dMkqfy2el8A8/I76n2Hi1oBFEbG1SfxD2l5nhwXV3XjlnOmwxJlQbYpJH4W51odnU9sARCSAgv7S3CyAFMkpYg=="
+        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
         "resolved": "10.0.9",
-        "contentHash": "VzIU41Sb23Em98hDQc71LPwKTC72xkiG7lpCZaIkf84jBJW+ViaKPa24qqR4FPmj1N4vDWilzs6Dq5Om8aFj+Q==",
-        "dependencies": {
-          "System.Memory": "4.6.3",
-          "System.Runtime.CompilerServices.Unsafe": "6.1.2"
-        }
+        "contentHash": "VzIU41Sb23Em98hDQc71LPwKTC72xkiG7lpCZaIkf84jBJW+ViaKPa24qqR4FPmj1N4vDWilzs6Dq5Om8aFj+Q=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
         "resolved": "10.0.9",
-        "contentHash": "s2PcxHK4IYQ6gmD3VSBkym9tWGkFisKjcjWBdl7a+n4Yy66ae4beJ1ZdjDp060SSll4W3Rt4H2LW87dWckv+QQ==",
-        "dependencies": {
-          "System.Security.Principal.Windows": "5.0.0"
-        }
+        "contentHash": "s2PcxHK4IYQ6gmD3VSBkym9tWGkFisKjcjWBdl7a+n4Yy66ae4beJ1ZdjDp060SSll4W3Rt4H2LW87dWckv+QQ=="
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
         "resolved": "10.0.9",
-        "contentHash": "raEAXJHu1ERuQnLhfaMUhK19A+i/CLHH5tFWi+azKxq2O4kzgvdeNuZTzMzyT7pyM1+zE2Pqb2g/DXJsuPp/LQ==",
-        "dependencies": {
-          "System.Buffers": "4.6.1",
-          "System.Memory": "4.6.3",
-          "System.Threading.Tasks.Extensions": "4.6.3"
-        }
-      },
-      "System.Management": {
-        "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "8GgwcQgAv1Xg0z4vkJ759AJOFbZpK17cX9+21SOHo+KXS+VUhwSBeFSzjDJyyaEiJwgQ0D5sGnfpEs2hjyZrmA==",
-        "dependencies": {
-          "System.CodeDom": "10.0.8"
-        }
-      },
-      "System.Memory": {
-        "type": "Transitive",
-        "resolved": "4.6.3",
-        "contentHash": "qdcDOgnFZY40+Q9876JUHnlHu7bosOHX8XISRoH94fwk6hgaeQGSgfZd8srWRZNt5bV9ZW2TljcegDNxsf+96A=="
-      },
-      "System.Runtime.CompilerServices.Unsafe": {
-        "type": "Transitive",
-        "resolved": "6.1.2",
-        "contentHash": "2hBr6zdbIBTDE3EhK7NSVNdX58uTK6iHW/P/Axmm9sl1xoGSLqDvMtpecn226TNwHByFokYwJmt/aQQNlO5CRw=="
-      },
-      "System.Security.Principal.Windows": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "t0MGLukB5WAVU9bO3MGzvlGnyJPgUlcwerXn1kzBRjwLKixT96XV0Uza41W49gVd8zEMFu9vQEFlv0IOrytICA=="
+        "contentHash": "raEAXJHu1ERuQnLhfaMUhK19A+i/CLHH5tFWi+azKxq2O4kzgvdeNuZTzMzyT7pyM1+zE2Pqb2g/DXJsuPp/LQ=="
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
         "resolved": "10.0.9",
-        "contentHash": "65bbI+LWcVgq1mzPtv6bJF+ZXeeIawld/puK9ixD1l3gJGM2IU4gkYbZoKLVjsXJXbrZqSRf86RlKf1TcCTY1Q==",
-        "dependencies": {
-          "System.Buffers": "4.6.1",
-          "System.Memory": "4.6.3",
-          "System.Runtime.CompilerServices.Unsafe": "6.1.2"
-        }
+        "contentHash": "65bbI+LWcVgq1mzPtv6bJF+ZXeeIawld/puK9ixD1l3gJGM2IU4gkYbZoKLVjsXJXbrZqSRf86RlKf1TcCTY1Q=="
       },
       "System.Text.Json": {
         "type": "Transitive",
         "resolved": "10.0.9",
         "contentHash": "mD4f7hUvjXEbLAnROibQswbYguGnfzN17gtkuqAHU1a0gJsqe7LXtV+0tItJsYrCBBpPYHiHFlLtjzG2ZEt5uQ==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
-          "System.Buffers": "4.6.1",
           "System.IO.Pipelines": "10.0.9",
-          "System.Memory": "4.6.3",
-          "System.Runtime.CompilerServices.Unsafe": "6.1.2",
-          "System.Text.Encodings.Web": "10.0.9",
-          "System.Threading.Tasks.Extensions": "4.6.3"
+          "System.Text.Encodings.Web": "10.0.9"
         }
-      },
-      "System.Threading.Tasks.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.6.3",
-        "contentHash": "7sCiwilJLYbTZELaKnc7RecBBXWXA+xMLQWZKWawBxYjp6DBlSE3v9/UcvKBvr1vv2tTOhipiogM8rRmxlhrVA=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "CentralTransitive",
@@ -398,9 +625,7 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.Options": "10.0.9",
-          "System.Buffers": "4.6.1",
-          "System.Diagnostics.DiagnosticSource": "10.0.9",
-          "System.Memory": "4.6.3"
+          "System.Diagnostics.DiagnosticSource": "10.0.9"
         }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
@@ -423,9 +648,347 @@
         "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "System.Buffers": "4.6.1",
-          "System.Diagnostics.DiagnosticSource": "10.0.9",
-          "System.Memory": "4.6.3"
+          "System.Diagnostics.DiagnosticSource": "10.0.9"
+        }
+      }
+    },
+    "net9.0": {
+      "CliWrap": {
+        "type": "Direct",
+        "requested": "[3.10.2, )",
+        "resolved": "3.10.2",
+        "contentHash": "oW63Lh5Tr2dVRnGSn5UyV2ITAYTdyaGB8r4pGMcz7CwfzketV7ANyn2LvNJtOjXjL/tJbG0qDH8Xwgt3jgGMNg=="
+      },
+      "DotNet.ReproducibleBuilds": {
+        "type": "Direct",
+        "requested": "[2.0.5, )",
+        "resolved": "2.0.5",
+        "contentHash": "8LrlvI1KpjjJ4VGSqZ16yoOCKlQnYS+Y8rYNifNrscmVh5anJcF9E4e0NiDP30BHBMUbkoJ5KdcxoRWM7Pz9Aw=="
+      },
+      "JetBrains.Annotations": {
+        "type": "Direct",
+        "requested": "[2026.2.0, )",
+        "resolved": "2026.2.0",
+        "contentHash": "drvAEaI7Xf4wU6dx4UTB9MoZWXZlraaQ0qoeThPQ411FxNhId7QdUTukIC9I8aUHP0ycAaGwZNKqSvfOZQvUlg=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Direct",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "HTgnvmK0ubesUFO16pLC+i9+RS8lEGd6TmDouuy75FsAgIFrSwUVhYCqG2IENzBJwgxGc/6Rsulfsvd9ZG/XkA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.9",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.9",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Json": "10.0.9",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.9",
+          "Microsoft.Extensions.Logging.Console": "10.0.9",
+          "Microsoft.Extensions.Logging.Debug": "10.0.9",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.9",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "8D4HaqxWdm5M/nuhQffjPoR1ekhlpyKTXjFMAT5KlP0dvxkJe5JLAP6MAsuUEUxKWG09Bi5aAUaYMFKrMqWHqA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "JhKySWIL8+N4yFt4HPm1rGKCHooze+MBdTdpXc0bd/PGm31TrSUi2m0Nek1y441Wlv/RE6VH0W/DCv2xnmy8FA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "NgLB9cYnIb0/djSDcnqo4GIGGWooxGmr/gCUe3/CRXcKqLizOFui8MyW4EVkTB/KNJL+oXdMXnD6ZRm3Y+qkrQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "LiFKJgc9jZEW+7RhcSfsvCwoikt1lDdOqOn+whZC5zVHyg/gExftHl2QPtmfiHsEdDNg+Y+BDr6835tOfj8Y7A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "System.Text.Json": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "ockJRreRW/HbGwoyHzYOxMucFBimvAZ8lKNwQLMHrS6mwkDUaCJMWzzeE+Rm9vgFlv2o/xqk8fm+FpqrDCnkTA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Json": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "NijozhERJDIaJ4k5TSMy1jOi0cSC2HfkvRD/Sl+kGSSKgVbFnF4GxgtMN/MrzHB8D1JxIrD4xSer9Blh9v3axQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "NLXI3PbTe39q6/sgs7JYhmfPf7bMzReUoAJ0q9Po6yhfM+0anZa7PrEva4W2SdiLWGyB9eKZS9THGt2BP40xJg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "zm8WVod4swgprGrkxkuSILlbXqdDRqF+3y6U0I7jlmj4PMyKN6d8pzXZHUn5lr/gZVULzk/+FeTYlTupt6akpg==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "mvRf9qOH/LslWIee/h+lsElnoUyKotEwoPL31soqScmO/eoxObaTCLCdx2DdqPdRi9LnB+7qKZ49jfyrLZuc+w=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "N7Gm9SjugYjmmnhwbBKC9DFqGqjfJvh6YfOJgtwh0AW0Xpok3dIVors1ik050XmUxKAgAc7nNngDIJyFb06K2g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "bUth5ip7YsZMXWZS42IRTI0zDrPEqdE+xnsmcL0Pk784grWKApDvc5UoMi2tP2qYJ5ylFzeVDuDu08sFATq1bg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "WyZEG/O8jKqBOBF6/M6IJqiEyWFBUv6PDyzNoXDA0mBZwKtkuf7GiZ/0/8eU8OpLKKQL0O95oPOY1szrWIKofQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "System.Text.Json": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "r/A0ahpXmZH/8ltPjrFFWp12BIizK9cCVJXPcHyOad8e4eIX7P/geW+uBYdczkeCAaMebT4jEU7snOm4GnmKfA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "goAl30/WwmdnWDPRwATaDPIK0iuDBnQSMTH2XYGVB1SwReg7hglhvDNjjpNhT25US3GF4I5q6BhTNs6nFYzEfg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "System.Diagnostics.EventLog": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "tHynPVHbTicuaDpS2JVTxX0qA5VTg15CXgVKTwWvvudb5BvW5aVew8MMyek6LrDGAom7UbON1jf1T5GhpTilFA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9",
+          "System.Text.Json": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Y4E24zffF/aPS0igNvY6ZzAQfbxd6AYdC9L4brnH+uK0yYYHIR6FeGVQVVjAOo8wub1EQDl2B90lCcpqoTF7Yw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "VzIU41Sb23Em98hDQc71LPwKTC72xkiG7lpCZaIkf84jBJW+ViaKPa24qqR4FPmj1N4vDWilzs6Dq5Om8aFj+Q=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "s2PcxHK4IYQ6gmD3VSBkym9tWGkFisKjcjWBdl7a+n4Yy66ae4beJ1ZdjDp060SSll4W3Rt4H2LW87dWckv+QQ=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "raEAXJHu1ERuQnLhfaMUhK19A+i/CLHH5tFWi+azKxq2O4kzgvdeNuZTzMzyT7pyM1+zE2Pqb2g/DXJsuPp/LQ=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "65bbI+LWcVgq1mzPtv6bJF+ZXeeIawld/puK9ixD1l3gJGM2IU4gkYbZoKLVjsXJXbrZqSRf86RlKf1TcCTY1Q=="
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "mD4f7hUvjXEbLAnROibQswbYguGnfzN17gtkuqAHU1a0gJsqe7LXtV+0tItJsYrCBBpPYHiHFlLtjzG2ZEt5uQ==",
+        "dependencies": {
+          "System.IO.Pipelines": "10.0.9",
+          "System.Text.Encodings.Web": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "woZsWLhOQsASuxbmgiZJqiGUBNo3IjRdXC92xt8rRokza+P6/nIsnzq7sm9Or6ZYcRl2kL1ufj8HVzp1QlPTXw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "Tp/+LPb70RyjjtLg9m5C959eP4KrUpJHThZfAegZVpsfmGvzfuNkuYbI/ft+LvXhMSyUcAeOPaN6rzTccwnZAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "System.Diagnostics.DiagnosticSource": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "System.Diagnostics.DiagnosticSource": "10.0.9"
         }
       }
     }


### PR DESCRIPTION
BREAKING CHANGE: netstandard2.1 support removed; consumers on .NET Framework or pre-net8 targets are no longer supported.