### PR TITLE
chore: extend shared Arkanis Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "config:recommended"
+        "github>ArkanisCorporation/renovate-config"
     ],
     "labels": [
         "automated"


### PR DESCRIPTION
Extends the shared Arkanis Renovate preset (`github>ArkanisCorporation/renovate-config`) so this repo inherits org-wide dependency policy. Any repo-specific Renovate rules are preserved unchanged. Closes #61.